### PR TITLE
update next_page_url for beta design (fixes #28)

### DIFF
--- a/furaffinity-dl
+++ b/furaffinity-dl
@@ -119,7 +119,7 @@ https://github.com/Xerbo/furaffinity-dl/issues" >&2
 	fi
 
 	# Get URL for next page out of "Next" button. Required for favorites, pages of which are not numbered
-	next_page_url="$(grep '<a class="button-link right" href="' "$tempfile" | grep '">Next &nbsp;&#x276f;&#x276f;</a>' | cut -d '"' -f 4 | sort -u)"
+	next_page_url="$(grep -B 1 'type="submit">Next' "$tempfile" | grep form | cut -d '"' -f 2 | uniq)"
 
 	# Extract links to pages with individual artworks and iterate over them
 	artwork_pages="$(grep '<a href="/view/' "$tempfile" | grep -E --only-matching '/view/[[:digit:]]+/' | uniq)"


### PR DESCRIPTION
Quick and dirty but gets the job done, tested on a gallery that'd previously only get 1 page but now gets entire gallery.
Tested both with and without signing in.

This will also obviously break for anyone not using the new design, in case you actually care about naysayers ;p (You have to actively opt out)