### PR TITLE
Revert to old full URL grepping (fixes #33 and #34)

### DIFF
--- a/furaffinity-dl
+++ b/furaffinity-dl
@@ -142,11 +142,7 @@ https://github.com/Xerbo/furaffinity-dl/issues" >&2
 		# Get the full size image URL.
 		# This will be a facdn.net link, we will default to HTTPS
 		# but this can be disabled with -i or --http for specific reasons
-		if [ $classic = true ]; then
-			image_url="$prefix$(grep --only-matching --max-count=1 ' href="//d.facdn.net/art/.\+">Download' "$tempfile" | cut -d '"' -f 2)" 
-		else
-			image_url="$prefix$(grep --only-matching --max-count=1 ' href="//d.facdn.net/download/art/.\+">Download' "$tempfile" | cut -d '"' -f 2)"
-		fi
+		image_url="$prefix$(grep --only-matching --max-count=1 ' href="//d.facdn.net/art/.\+">Download' "$tempfile" | cut -d '"' -f 2)" 
 
 		# Get metadata
 		description="$(grep 'og:description" content="' "$tempfile" | cut -d '"' -f 4)"


### PR DESCRIPTION
It appears the devs at furaffinity can't decide how to do download links
They've reverted to the old style, naturally we do the same.

I've tested this myself and it's working as intended.