### PR TITLE
Fix output filename can not begin with '-'

### DIFF
--- a/furaffinity-dl
+++ b/furaffinity-dl
@@ -79,11 +79,11 @@ if [ -z "$(command -v exiftool)" ]; then
 fi
 
 cleanup() {
-	rm "$tempfile"
+	rm -f "$tempfile"
 }
 
 # Attempt to create the output directory
-mkdir -p "$outdir"
+mkdir -p -- "$outdir"
 
 # Setup temporarily file with 600 perms
 tempfile="$(umask u=rwx,g=,o= && mktemp --suffix=_fa-dl)"
@@ -176,7 +176,7 @@ https://github.com/Xerbo/furaffinity-dl/issues" >&2
 			echo "File already exists, skipping. Use -w to skip this check"
 		fi
 
-		mime_type="$(file "$file")"
+		mime_type="$(file -- "$file")"
 
 		if [ $textmeta = true ]; then
 			 echo -ne "Title: $title\nURL: $page\nFilename: $file_name\nDescription: $description" > "$file.meta"
@@ -187,16 +187,16 @@ https://github.com/Xerbo/furaffinity-dl/issues" >&2
 			# Use eyeD3 for injecting metadata into audio files (if it's installed)
 			if [ $eyed3 = true ] && [ $metadata = true ]; then
 				if [ -z "$description" ]; then
-					eyeD3 -t "$title" "$file" || true
+					eyeD3 -t "$title" -- "$file" || true
 				else
 					# HACK: eyeD3 throws an error if a description containing a ":"
-					eyeD3 -t "$title" --add-comment "${description//:/\\:}" "$file" || true
+					eyeD3 -t "$title" --add-comment "${description//:/\\:}" -- "$file" || true
 				fi
 			fi
 		elif [[ $mime_type == *"image"* ]]; then
 			# Use exiftool for injecting metadata into pictures (if it's installed)
 			if [ $exiftool = true ] && [ $metadata = true ]; then
-				exiftool "$file" -description="$description" -title="$title" -overwrite_original || true
+				cat -- "$file" | exiftool -description="$description" -title="$title" -overwrite_original - > "$tempfile" && mv -- "$tempfile" "$file" || true
 			fi
 		fi
 


### PR DESCRIPTION
When somebody wants to use a output directory name begin with `-`, some program (mkdir, file, ...) which invoked by furaffinity-dl will not work.

Some users' name begin with `-`, this problem is confusing for people who want that directory name is same as user names.

```
$ ./furaffinity-dl -c cookies.txt -r -o '-zek-' gallery/-zek-/
mkdir: invalid option -- 'z'
Try 'mkdir --help' for more information.
```

This patch has fixed the problem.

It's worth noting that `exiftool` doesn't understand the meaning of `--`, so I had to use temporary file as a hack