### PR TITLE
Python version: Fix downloading multiple Favorites gallery pages

### DIFF
--- a/furaffinity-dl.py
+++ b/furaffinity-dl.py
@@ -183,7 +183,18 @@ while True:
     for img in s.findAll('figure'):
         download(img.find('a').attrs.get('href'))
 
-    page_num += 1
+    # Favorites galleries use a weird timestamp system, so grab the next "page" from the Next button
+    if args.category == 'favorites':
+        next_button = s.find('a', class_='button standard right')
+        if next_button is None:
+            break
+
+        # URL looks something like /favorites/:username/:timestamp/next
+        # Splitting on the username is more robust to future URL changes
+        page_num = next_button.attrs['href'].split(args.username + '/')[-1]
+    else:
+        page_num += 1
+    
     print('Downloading page', page_num)
 
 print('Finished downloading')


### PR DESCRIPTION
### Problem
The favorites pages work differently from the gallery/scraps pages by using timestamps and next/prev indicators instead of standard pagination. Downloading favorites using standard pagination results in an infinite loop.

### Solution
This change pulls the timestamp from the **Next** button on each favorites page for proper page navigation. Gallery/scraps downloads are unaffected.

### Considerations
The script on each favorites page will say something like `Downloading page 593172859/next`. Maybe you'd like it to say something different?