### PR TITLE
fix image url not matching some unicode char

### DIFF
--- a/furaffinity-dl
+++ b/furaffinity-dl
@@ -150,7 +150,7 @@ https://github.com/Xerbo/furaffinity-dl/issues" >&2
 		# Get the full size image URL.
 		# This will be a facdn.net link, we will default to HTTPS
 		# but this can be disabled with -i or --http for specific reasons
-		image_url="$prefix$(grep --only-matching --max-count=1 ' href="//d.facdn.net/art/.\+">Download' "$tempfile" | cut -d '"' -f 2)" 
+		image_url="$prefix$(grep --only-matching --max-count=1 ' href="//d.facdn.net/art/[^"]\+">Download' "$tempfile" | cut -d '"' -f 2)" 
 
 		# Get metadata
 		description="$(grep 'og:description" content="' "$tempfile" | cut -d '"' -f 4)"


### PR DESCRIPTION
The current regular expression for image URL matching (`' href="//d.facdn.net/art/.\+">Download'`) will not match URLs that contain certain Unicode characters (e.g., `<a class="button standard mobile-fix" href="//d.facdn.net/art/istani/1560251251/1560251251.istani_카르투하검로드３.png">Download</a>`).

I'm not sure if this is a `grep` issue, but changing the expression to match all non-quote characters (`' href="//d.facdn.net/art/[^"]\+">Download'`) will fix this issue.