### PR TITLE
Fix Next button in gallery download.

### DIFF
--- a/furaffinity-dl.py
+++ b/furaffinity-dl.py
@@ -203,12 +203,12 @@ while True:
         sleep(args.interval)
 
     if args.category != "favorites":
-        next_button = s.find('button', class_='button standard', text="Next").parent
-        if next_button is None:
+        next_button = s.find('button', class_='button standard', text="Next")
+        if next_button is None or next_button.parent is None:
             print('Unable to find next button')
             break
 
-        page_num = next_button.attrs['action'].split('/')[-2]
+        page_num = next_button.parent.attrs['action'].split('/')[-2]
 
         print('Downloading page', page_num, page_url)
     else:


### PR DESCRIPTION
In the current code, if the next button is not found, there is nothing
stopping the call to `(null).parent`. While this doesn't impact the
main operation of the tool, it does cause the program to 
crash at the end instead of exiting gracefully.

This adjusts the call to check if the button is found, and then
also checks if the parent is found.