### PR TITLE
Add stop page option

### DIFF
--- a/furaffinity-dl.py
+++ b/furaffinity-dl.py
@@ -31,6 +31,7 @@ parser.add_argument('--output', '-o', dest='output', type=str, default='.', help
 parser.add_argument('--cookies', '-c', dest='cookies', type=str, default='', help="path to a NetScape cookies file")
 parser.add_argument('--ua', '-u', dest='ua', type=str, default='Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:68.7) Gecko/20100101 Firefox/68.7', help="Your browser's useragent, may be required, depending on your luck")
 parser.add_argument('--start', '-s', dest='start', type=str, default=1, help="page number to start from")
+parser.add_argument('--stop', '-S', dest='stop', type=str, default='', help="Page number to stop on. For favorites pages, specify the full URL after the username (1234567890/next).")
 parser.add_argument('--dont-redownload', '-d', const='dont_redownload', action='store_const', help="Don't redownload files that have already been downloaded")
 parser.add_argument('--interval', '-i', dest='interval', type=float, default=0, help="delay between downloading pages")
 parser.add_argument('--metadir', '-m', dest='metadir', type=str, default=None, help="directory to put meta files in")
@@ -170,6 +171,10 @@ def download(path):
 
 # Main downloading loop
 while True:
+    if args.stop and args.stop == page_num:
+        print(f"Reached page {args.stop}, stopping.")
+        break
+
     page_url = '{}/{}'.format(gallery_url, page_num)
     response = session.get(page_url)
     s = BeautifulSoup(response.text, 'html.parser')


### PR DESCRIPTION
Add an option to specify a stop page when downloading. This is
especially useful when downloading large galleries where you've already
run this tool in the past.