### PR TITLE
fixed exception for posts with no tags

### DIFF
--- a/furaffinity-dl.py
+++ b/furaffinity-dl.py
@@ -132,8 +132,11 @@ def download(path):
     }
 
     # Extact tags
-    for tag in s.find(class_='tags-row').findAll(class_='tags'):
-        data['tags'].append(tag.find('a').text)
+    try:
+        for tag in s.find(class_='tags-row').findAll(class_='tags'):
+            data['tags'].append(tag.find('a').text)
+    except:
+        pass
 
     # Extract comments
     for comment in s.findAll(class_='comment_container'):


### PR DESCRIPTION
For the python verison of the downloader, I recieved this exception:
```
line 135, in download
    for tag in s.find(class_='tags-row').findAll(class_='tags'):
AttributeError: 'NoneType' object has no attribute 'findAll'
```

I made a quick fix by wrapping the for loop with a try and except block.